### PR TITLE
Do not download package on each run

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,8 +90,8 @@ default['openstack']['omnibus']['projects'] = {
       'nova-cert' => {
         'command' => 'bin/nova-cet'
       },
-      'nova-vncproxy' => {
-        'command' => 'bin/nova-vncproxy'
+      'nova-novncproxy' => {
+        'command' => 'bin/nova-novncproxy'
       },
       'nova-consoleauth' => {
         'command' => 'bin/nova-consoleauth'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -17,22 +17,26 @@
 # limitations under the License.
 #
 
-package_install_method = node['openstack']['omnibus']['package_install_method']
-
-case package_install_method
+case node['openstack']['omnibus']['package_install_method']
 when 'repo'
-  package node['openstack']['omnibus']['package_name'] do
-    action :install
-  end
+  package node['openstack']['omnibus']['package_name']
 when 'url'
-  package = node['openstack']['omnibus']['package_url']
-  unless package.nil?
-    bash 'install openstack' do
-      user 'root'
-      cwd '/tmp'
-      code <<-EOH
-      URL='#{package}'; FILE=`mktemp`; wget "$URL" -qO $FILE && sudo dpkg -i $FILE; rm $FILE
-      EOH
+  package_url = node['openstack']['omnibus']['package_url']
+
+  unless package_url.nil?
+    package_name = package_url.split('/')[-1]
+    download_path = "/tmp/#{package_name}"
+
+    if ::File.exists?(download_path)
+      Chef::Log.info("#{download_path} already exists, skipping download")
+    else
+      remote_file download_path do
+        source package_url
+      end
+    end
+
+    dpkg_package package_name do
+      source download_path
     end
   end
 end


### PR DESCRIPTION
This change adds some conditionals to not download the large OpenStack
omnibus package on each chef run.  Will need to be updated to work with
Red Hat-based distros.
