### PR TITLE
Change nova-vncproxy to nova-novncproxy

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -90,8 +90,8 @@ default['openstack']['omnibus']['projects'] = {
       'nova-cert' => {
         'command' => 'bin/nova-cet'
       },
-      'nova-vncproxy' => {
-        'command' => 'bin/nova-vncproxy'
+      'nova-novncproxy' => {
+        'command' => 'bin/nova-novncproxy'
       },
       'nova-consoleauth' => {
         'command' => 'bin/nova-consoleauth'


### PR DESCRIPTION
Stackforge compute cookbook refers to nova-novncproxy, not
nova-vncproxy.  It looks like nova-vncproxy was removed from nova quite
some time ago.
