### PR TITLE
Add more scripts to alternatives system

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -104,6 +104,9 @@ default['openstack']['omnibus']['projects'] = {
       },
       'nova-network' => {
         'command' => 'bin/nova-network'
+      },
+      'nova-dhcpbridge' => {
+        'command' => 'bin/nova-dhcpbridge'
       }
     }
   },

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,6 +51,9 @@ default['openstack']['omnibus']['projects'] = {
     'config_dir' => '/etc/glance',
     'log_dir' => '/var/log/glance',
     'user' => 'glance',
+    'commands' => [
+      'bin/glance-manage'
+    ],
     'services' => {
       'glance-api' => {
         'command' => 'bin/glance-api',
@@ -68,6 +71,9 @@ default['openstack']['omnibus']['projects'] = {
     'config_dir' => '/etc/nova',
     'log_dir' => '/var/log/nova',
     'user' => 'nova',
+    'commands' => [
+      'bin/nova-manage'
+    ],
     'services' => {
       'nova-api-os-compute' => {
         'command' => 'bin/nova-api-os-compute'
@@ -107,6 +113,9 @@ default['openstack']['omnibus']['projects'] = {
     'config_dir' => '/etc/cinder',
     'log_dir' => '/var/log/cinder',
     'user' => 'cinder',
+    'commands' => [
+      'bin/cinder-manage'
+    ],
     'services' => {
       'cinder-api' => {
         'command' => 'bin/cinder-api'


### PR DESCRIPTION
Currently, stackforge cookbooks execute a number of different -manage
scripts.  This change adds more of these scripts to the alternatives
system so the cookbooks can find these scripts under /opt/openstack
correctly.
