### PR TITLE
Remove --config-dir argument from upstart scripts

### DIFF
--- a/templates/default/upstart/openstack-service.erb
+++ b/templates/default/upstart/openstack-service.erb
@@ -6,4 +6,4 @@ respawn
 exec start-stop-daemon --start \
                        --chuid <%= @service_user %> \
                        --exec <%= @project_venv %>/<%= @service_command %> \
-                       -- <% for conf in @config_files -%>--config-file <%= conf %><% end %> --config-dir <%= @project_config_dir %>
+                       -- <% for conf in @config_files -%>--config-file <%= conf %><% end %>


### PR DESCRIPTION
This causes issues w/ glance specifically as it will try loading
/etc/glance/*.conf but glance-api and glance-registry only need to
load their respective configuration files.  Also, according to
http://docs.openstack.org/developer/glance/configuring.html, if
config-dir is set, then –config-file is ignored.
