### PR TITLE
Unset block-storage package attributes

### DIFF
--- a/recipes/node_attributes.rb
+++ b/recipes/node_attributes.rb
@@ -83,8 +83,6 @@ if enabled_projects.include? 'block-storage'
     cinder_scheduler
     cinder_scheduler_service
     cinder_ceph
-    cinder_iscsitarget
-    cinder_iscsitarget_service
     cinder_nfs
     cinder_emc
   ).each do |type|

--- a/recipes/node_attributes.rb
+++ b/recipes/node_attributes.rb
@@ -70,6 +70,28 @@ if enabled_projects.include? 'compute'
   end
 end
 
+if enabled_projects.include? 'block-storage'
+  %w(
+    mysql_python
+    postgresql_python
+    cinder_common
+    cinder_api
+    cinder_api_service
+    cinder_client
+    cinder_volume
+    cinder_volume_service
+    cinder_scheduler
+    cinder_scheduler_service
+    cinder_ceph
+    cinder_iscsitarget
+    cinder_iscsitarget_service
+    cinder_nfs
+    cinder_emc
+  ).each do |type|
+    node.set['openstack']['block-storage']['platform']["#{type}_packages"] = []
+  end
+end
+
 if enabled_projects.include? 'dashboard'
   %w(
     mysql_python


### PR DESCRIPTION
Currently installing an AIO w/ stackforge cookbooks results in cinder
packages getting installed.  This change unsets the block-storage
attributes to ensure none of those packages get installed.
