### PR TITLE
Update recursive cp for config files

### DIFF
--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -52,18 +52,19 @@ enabled_projects.each do |project|
     action :create
   end
 
-  # while i hate the execute resource, there is really
-  # no better way to do this
-  execute "Copy default configuration from #{project}" do
-    omnibus_project_etc_path = "#{omnibus_path}/#{project_name}/etc"
-    # some projects have configs in project/etc/project, whilst others have configs in
-    # project/etc/
-    if FileTest.directory?("#{omnibus_project_etc_path}/#{project_name}")
-      command "cp -R #{omnibus_project_etc_path}/#{project_name}/* /etc/#{project_name}"
-    else
-      command "cp -R #{omnibus_project_etc_path}/* /etc/#{project_name}"
-    end
-    action :run
-  end
+  # some projects have configs in project/etc/project, whilst others have configs in
+  # project/etc/
+  # a ruby_block is used here as we need the evaluation to happen at execution time
+  # and not compile time when omnibus_path does not yet exist
+  ruby_block "Copy default configuration from #{project}" do
+    block do
+      omnibus_project_etc_path = "#{omnibus_path}/#{project_name}/etc"
 
+      if FileTest.directory?("#{omnibus_project_etc_path}/#{project_name}")
+        FileUtils.cp_r Dir.glob("#{omnibus_project_etc_path}/#{project_name}/*"), "/etc/#{project_name}"
+      else
+        FileUtils.cp_r Dir.glob("#{omnibus_project_etc_path}/*"), "/etc/#{project_name}"
+      end
+    end
+  end
 end

--- a/recipes/setup.rb
+++ b/recipes/setup.rb
@@ -55,7 +55,14 @@ enabled_projects.each do |project|
   # while i hate the execute resource, there is really
   # no better way to do this
   execute "Copy default configuration from #{project}" do
-    command "cp -R #{omnibus_path}/#{project_name}/etc/* /etc/#{project_name}"
+    omnibus_project_etc_path = "#{omnibus_path}/#{project_name}/etc"
+    # some projects have configs in project/etc/project, whilst others have configs in
+    # project/etc/
+    if FileTest.directory?("#{omnibus_project_etc_path}/#{project_name}")
+      command "cp -R #{omnibus_project_etc_path}/#{project_name}/* /etc/#{project_name}"
+    else
+      command "cp -R #{omnibus_project_etc_path}/* /etc/#{project_name}"
+    end
     action :run
   end
 


### PR DESCRIPTION
Some projects have configs in project/etc/project, whilst others have
configs in project/etc.  This change will check for project/etc/project
so that we're copying files into place correctly.

We also move this code into a ruby_block so that the conditional code
is evaluated at execution time and not compile time (when
/opt/openstack does not yet exist).  It may be cleaner to create
attributes for this to indicate where to copy configs from, but for now
this appears to work fine.
